### PR TITLE
Remove Non-Breaking space from description

### DIFF
--- a/src/objects/Opportunity.object
+++ b/src/objects/Opportunity.object
@@ -769,7 +769,7 @@
     </fields>
     <fields>
         <fullName>Acknowledgment_Status__c</fullName>
-        <description>The acknowledgement status of this Opportunity. </description>
+        <description>The acknowledgement status of this Opportunity.</description>
         <externalId>false</externalId>
         <inlineHelpText>The acknowledgement status of this Opportunity.</inlineHelpText>
         <label>Acknowledgment Status</label>


### PR DESCRIPTION
The Acknowledgement_Status__c field's description contains a non-breaking space at the end.
This caused deployment tool to fail. I'm not sure if this is the best way to propose it, so just throwing it out there.

File name: objects/Opportunity.object (Line: 1: Column:74897):  Message: Cannot modify managed object: entity=CustomFieldDefinition, component=00N36000006hiwG, field=Description, state=installed: newValue='The acknowledgement status of this Opportunity.ÃƒÂ‚Ã‚Â ', oldValue='The acknowledgement status of this Opportunity.Â '

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
